### PR TITLE
Configurable temporary file directory preferred over sys_get_temp_dir()

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -98,10 +98,10 @@ class File
      */
     public static function getTempDir()
     {
-        if (function_exists('sys_get_temp_dir')) {
-            return sys_get_temp_dir();
-        } elseif ( ($tmp = getenv('TMP')) || ($tmp = getenv('TEMP')) || ($tmp = getenv('TMPDIR')) ) {
+        if (($tmp = getenv('TMP')) || ($tmp = getenv('TEMP')) || ($tmp = getenv('TMPDIR'))) {
             return realpath($tmp);
+        } elseif ( function_exists('sys_get_temp_dir') ) {
+            return sys_get_temp_dir();
         } else {
             return '/tmp';
         }


### PR DESCRIPTION
I ran into problems with a library(phpwkhtmltopdf) that has a dependency on this library library because the temporary files were not being created due to changes in OSX.

The latest version of OSX seems to break tempnam() when used with directory returned by sys_get_temp_dir(). I wanted a way to manually define temporary directory and created this PR. What are your thoughts on this?
