### PR TITLE
fix non-ASCII filnemae garbled on Internet Explorer

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -83,7 +83,7 @@ class File
 
         if ($filename!==null || $inline) {
             $disposition = $inline ? 'inline' : 'attachment';
-            header("Content-Disposition: $disposition; filename=\"$filename\"");
+            header('Content-Disposition: ' . $disposition . '; filename*=UTF-8\'\''.rawurlencode($filename));
         }
 
         readfile($this->_fileName);

--- a/src/File.php
+++ b/src/File.php
@@ -83,7 +83,7 @@ class File
 
         if ($filename!==null || $inline) {
             $disposition = $inline ? 'inline' : 'attachment';
-            header('Content-Disposition: ' . $disposition . '; filename*=UTF-8\'\''.rawurlencode($filename));
+            header('Content-Disposition: ' . $disposition . '; filename=' .$filename. '; filename*=UTF-8\'\''.rawurlencode($filename));
         }
 
         readfile($this->_fileName);


### PR DESCRIPTION
## Issue
Filename include any non-ASCII characters corrupt on Internet Explorer.

## Description
- Set header `Content-Dispoistion` based on [RFC 6266](http://greenbytes.de/tech/tc2231/)  (RFC 2231/RFC 5987) specification.
- Use `rawurlencode` to convert the filename.