### PR TITLE
Fix getFileName()

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -113,7 +113,7 @@ class File
      */
     public function getFileName()
     {
-        return $this->_fileName;
+        return basename($this->_fileName);
     }
 
     /**


### PR DESCRIPTION
I think that `getFileName()` should return only file name not all path.
This allow path creation using `$tmp->getTempDir() . DIRECTORY_SEPARATOR . $tmp->getFileName()`