### PR TITLE
Fix invalid argument to mime_content_type()

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -106,7 +106,7 @@ class File
         if ($contentType !== null) {
             $headers['Content-Type'] = $contentType;
         } elseif (!isset($headers['Content-Type'])) {
-            $contentType = @mime_content_type($this->_filename);
+            $contentType = @mime_content_type($this->_fileName);
             if ($contentType === false) {
                 $contentType = self::DEFAULT_CONTENT_TYPE;
             }


### PR DESCRIPTION
Property names are case sensitive. A misspelled property led to this error:

> TypeError: mime_content_type(): Argument #<span/>1 ($filename) must be of type resource|string, null given in file /home/holger/beodata/composer/mikehaertl/php-tmpfile/src/File.php on line 111