### PR TITLE
Preserve state of ignore_user_abort()

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -136,10 +136,16 @@ class File
 
         // #28: File not cleaned up if user aborts connection during download
         if ($this->ignoreUserAbort) {
-            ignore_user_abort(true);
+            $ignoreUserAbort = ignore_user_abort(true);
         }
 
-        readfile($this->_fileName);
+        try {
+            readfile($this->_fileName);
+        } finally {
+            if (isset($ignoreUserAbort)) {
+                ignore_user_abort($ignoreUserAbort);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
`ignore_user_abort(true)` affects global state, possibly changing behaviour of subsequent code in unexpected ways.

This PR restores the setting to its previous state before returning.